### PR TITLE
The info argument to the LabelExpand(...) function was missing

### DIFF
--- a/draft-westerbaan-cfrg-hpke-xyber768d00.md
+++ b/draft-westerbaan-cfrg-hpke-xyber768d00.md
@@ -205,7 +205,7 @@ DHKEM and Kyber768Draft00.
 ~~~
 def DeriveKeyPair(ikm):
   dkp_prk = LabeledExtract("", "dkp_prk", ikm)
-  seed = LabeledExpand(dkp_prk, "sk", 32 + 64)
+  seed = LabeledExpand(dkp_prk, "sk", "", 32 + 64)
   seed1 = seed[0:32]
   seed2 = seed[32:96]
   sk1, pk1 = DHKEM.DeriveKeyPair(seed1)


### PR DESCRIPTION
The info argument to the LabelExpand(...) function in DeriveKeyPair(ikm) was missing. 

The info argument to the LabelExpand(...) function in DeriveKeyPair(ikm) was missing. I'm assuming its value is the empty string, "", equal to the value for DeriveKeyPair(ikm) in HPKE, RFC 9180.